### PR TITLE
Allow 0 and negative precision

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,11 +6,15 @@ function round(fn, x, precision) {
 		throw new TypeError('Expected value to be a number');
 	}
 
-	if (!numberIsInteger(precision) || precision < 0) {
-		throw new TypeError('Expected precision to be a positive integer');
+	if (!numberIsInteger(precision)) {
+		throw new TypeError('Expected precision to be an integer');
 	}
 
-	return Number(Math[fn](x + 'e' + precision) + 'e-' + precision);
+	var exponent = precision > 0 ? 'e' : 'e-';
+	var exponentNeg = precision > 0 ? 'e-' : 'e';
+	precision = Math.abs(precision);
+
+	return Number(Math[fn](x + exponent + precision) + exponentNeg + precision);
 }
 
 var fn = module.exports = round.bind(null, 'round');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "round-to",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "Round a number to a specific number of decimal places: 1.234 → 1.2",
   "license": "MIT",
   "repository": "sindresorhus/round-to",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "round-to",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Round a number to a specific number of decimal places: 1.234 → 1.2",
   "license": "MIT",
   "repository": "sindresorhus/round-to",

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,12 @@ roundTo.down(1.234, 2);
 //=> 1.23
 ```
 
+Numbers are rounded to a specific number of significant figures. Specifying a negative precision will round to any number of places to the left of the decimal.
+
+```js
+roundTo(1234.56, -2);
+//=> 1200
+```
 
 ## API
 

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ Type: `number`
 
 #### precision
 
-Type: `number` (positive integer)
+Type: `number` (integer)
 
 Number of decimal places.
 

--- a/test.js
+++ b/test.js
@@ -7,6 +7,8 @@ test('roundTo()', function (t) {
 	t.assert(fn(0.129, 2) === 0.13);
 	t.assert(fn(0.129, 1) === 0.1);
 	t.assert(fn(1.005, 2) === 1.01);
+	t.assert(fn(1.005, 0) === 1);
+	t.assert(fn(111.1, -2) === 100);
 	t.end();
 });
 
@@ -15,6 +17,8 @@ test('roundTo.up()', function (t) {
 	t.assert(fn.up(0.111, 2) === 0.12);
 	t.assert(fn.up(0.111, 1) === 0.2);
 	t.assert(fn.up(1.004, 2) === 1.01);
+	t.assert(fn.up(1.111, 0) === 2);
+	t.assert(fn.up(111.1, -2) === 200);
 	t.end();
 });
 
@@ -23,5 +27,7 @@ test('roundTo.down()', function (t) {
 	t.assert(fn.down(0.666, 2) === 0.66);
 	t.assert(fn.down(0.666, 1) === 0.6);
 	t.assert(fn.down(1.006, 2) === 1.00);
+	t.assert(fn.down(1.006, 0) === 1);
+	t.assert(fn.down(111.6, -2) === 100);
 	t.end();
 });


### PR DESCRIPTION
In a current project I am dealing with currencies (in cents) and need to be able to round cents to a whole dollar amount. For example, I need to get a number like `123.45` to round to `100`. In other words, negative precision.

This pull request makes negative precision possible.