### PR TITLE
Fix bug with negative numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ function round(fn, x, precision) {
 	if (fn === 'round') {
 		return Number(Math.sign(x) * (Math[fn](Math.abs(x) + exponent + precision) + exponentNeg + precision));
 	}
+	
 	return Number(Math[fn](x + exponent + precision) + exponentNeg + precision);
 }
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function round(fn, x, precision) {
 	var exponentNeg = precision > 0 ? 'e-' : 'e';
 	precision = Math.abs(precision);
 
-	if (fn === 'round')		{
+	if (fn === 'round') {
 		return Number(Math.sign(x) * (Math[fn](Math.abs(x) + exponent + precision) + exponentNeg + precision));
 	}
 	return Number(Math[fn](x + exponent + precision) + exponentNeg + precision);

--- a/index.js
+++ b/index.js
@@ -14,7 +14,10 @@ function round(fn, x, precision) {
 	var exponentNeg = precision > 0 ? 'e-' : 'e';
 	precision = Math.abs(precision);
 
-	return Number(Math[fn](x + exponent + precision) + exponentNeg + precision);
+	if(fn == "round")
+		return Number(Math.sign(x) * (Math[fn](Math.abs(x) + exponent + precision) + exponentNeg + precision));
+	else
+		return Number(Math[fn](x + exponent + precision) + exponentNeg + precision);
 }
 
 var fn = module.exports = round.bind(null, 'round');

--- a/index.js
+++ b/index.js
@@ -14,10 +14,10 @@ function round(fn, x, precision) {
 	var exponentNeg = precision > 0 ? 'e-' : 'e';
 	precision = Math.abs(precision);
 
-	if(fn == "round")
+	if (fn === 'round')		{
 		return Number(Math.sign(x) * (Math[fn](Math.abs(x) + exponent + precision) + exponentNeg + precision));
-	else
-		return Number(Math[fn](x + exponent + precision) + exponentNeg + precision);
+	}
+	return Number(Math[fn](x + exponent + precision) + exponentNeg + precision);
 }
 
 var fn = module.exports = round.bind(null, 'round');

--- a/index.js
+++ b/index.js
@@ -15,9 +15,9 @@ function round(fn, x, precision) {
 	precision = Math.abs(precision);
 
 	if (fn === 'round') {
-		return Number(Math.sign(x) * (Math[fn](Math.abs(x) + exponent + precision) + exponentNeg + precision));
+		return Number(Math.sign(x) * (Math.round(Math.abs(x) + exponent + precision) + exponentNeg + precision));
 	}
-	
+
 	return Number(Math[fn](x + exponent + precision) + exponentNeg + precision);
 }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "increment"
   ],
   "dependencies": {
-    "number-is-integer": "^1.0.1"
+    "number-is-integer": "^1.0.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "increment"
   ],
   "dependencies": {
-    "number-is-integer": "^1.0.0"
+    "number-is-integer": "^1.0.1"
   },
   "devDependencies": {
     "ava": "*",

--- a/test.js
+++ b/test.js
@@ -8,6 +8,7 @@ test('roundTo()', t => {
 	t.is(fn(1.005, 2), 1.01);
 	t.is(fn(1.005, 0), 1);
 	t.is(fn(111.1, -2), 100);
+	t.is(fn(-0.375, 2), -0.38);
 });
 
 test('roundTo.up()', t => {
@@ -17,6 +18,7 @@ test('roundTo.up()', t => {
 	t.is(fn.up(1.004, 2), 1.01);
 	t.is(fn.up(1.111, 0), 2);
 	t.is(fn.up(111.1, -2), 200);
+	t.is(fn.up(-0.375, 2), -0.37);
 });
 
 test('roundTo.down()', t => {
@@ -26,4 +28,5 @@ test('roundTo.down()', t => {
 	t.is(fn.down(1.006, 2), 1.00);
 	t.is(fn.down(1.006, 0), 1);
 	t.is(fn.down(111.6, -2), 100);
+	t.is(fn.down(-0.375, 2), -0.38);
 });


### PR DESCRIPTION
I was looking for Math.round() documentation when I came across this bug. After concluding that roundTo was not behaving as expected I tried to fix the problem. The problem was that with negative numbers, Math.round() would go to the hight number, thus, not producing the expected results.

To solve this I checked if the requested function was the "round" function and if this was verified then the function would be applied to the absolute value of the number to round and then multiplied by it's original sign.

Is this the correct way to do it?
Any feedback is appreciated.

Fixes #134