### PR TITLE
Support `Infinity` as `precision`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ declare const roundTo: {
 	Numbers are rounded to a specific number of fractional digits. Specifying a negative `precision` will round to any number of places to the left of the decimal.
 
 	@param number - Number to adjust.
-	@param precision - (Integer) Number of decimal places.
+	@param precision - (Integer or Infinity) Number of decimal places.
 
 	@example
 	```
@@ -24,7 +24,7 @@ declare const roundTo: {
 	Round up the decimals with [`Math.ceil`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/ceil).
 
 	@param number - Number to adjust.
-	@param precision - (Integer) number of decimal places.
+	@param precision - (Integer or Infinity) number of decimal places.
 
 	@example
 	```
@@ -40,7 +40,7 @@ declare const roundTo: {
 	Round down the decimals with [`Math.floor`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor).
 
 	@param number - Number to adjust.
-	@param precision - (Integer) number of decimal places.
+	@param precision - (Integer or Infinity) number of decimal places.
 
 	@example
 	```

--- a/index.js
+++ b/index.js
@@ -5,6 +5,10 @@ function round(method, number, precision) {
 		throw new TypeError('Expected value to be a number');
 	}
 
+	if (precision === Infinity) {
+		return number;
+	}
+
 	if (!Number.isInteger(precision)) {
 		throw new TypeError('Expected precision to be an integer');
 	}

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,13 @@ roundTo(1234.56, -2);
 //=> 1200
 ```
 
+Specifying an infinite `precision` will assume infinite decimal places.
+
+```js
+roundTo(0.1231782638, Infinity);
+//=> 0.1231782638
+```
+
 ## API
 
 ### roundTo(number, precision)
@@ -54,7 +61,7 @@ Number to adjust.
 
 #### precision
 
-Type: `number` (Integer)
+Type: `number` (Integer or Infinity)
 
 Number of decimal places.
 

--- a/test.js
+++ b/test.js
@@ -11,6 +11,7 @@ test('roundTo()', t => {
 	t.is(roundTo(-0.375, 2), -0.38);
 	t.false(Number.isNaN(roundTo(10000000000000, 8)));
 	t.is(roundTo(0.37542323423423432432432432432, 8), 0.37542323);
+	t.is(roundTo(0.1231782638, Infinity), 0.1231782638);
 });
 
 test('roundTo.up()', t => {


### PR DESCRIPTION
Specifying an infinite `precision` will assume infinite decimal places.

```js
roundTo(0.1231782638, Infinity);
//=> 0.1231782638
```

cc @sindresorhus 