### PR TITLE
Use `undefined` instead of `null`

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,6 @@ function round(method, number, precision) {
 	return result;
 }
 
-module.exports = round.bind(null, 'round');
-module.exports.up = round.bind(null, 'ceil');
-module.exports.down = round.bind(null, 'floor');
+module.exports = round.bind(undefined, 'round');
+module.exports.up = round.bind(undefined, 'ceil');
+module.exports.down = round.bind(undefined, 'floor');


### PR DESCRIPTION
In [`Function#bind`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind#Parameters), `thisArg` can be either `undefined` or `null`.