### PR TITLE
Fix some floating-point roundoff errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,9 +18,9 @@ function round(method, number, precision) {
 		number = Math.abs(number);
 	}
 
-	let power = Math.pow(10, precision);
+	const power = 10 ** precision;
 
-	let result = Math[method](+(number * power).toPrecision(15)) / power;
+	let result = Math[method](Number(number * power).toPrecision(15)) / power;
 
 	if (isRoundingAndNegative) {
 		result = -result;

--- a/index.js
+++ b/index.js
@@ -18,12 +18,9 @@ function round(method, number, precision) {
 		number = Math.abs(number);
 	}
 
-	let exponent;
-	[number, exponent] = `${number}e`.split('e');
-	let result = Math[method](`${number}e${Number(exponent) + precision}`);
+	let power = Math.pow(10, precision);
 
-	[number, exponent] = `${result}e`.split('e');
-	result = Number(`${number}e${Number(exponent) - precision}`);
+	let result = Math[method](+(number * power).toPrecision(15)) / power;
 
 	if (isRoundingAndNegative) {
 		result = -result;

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function round(method, number, precision) {
 
 	const power = 10 ** precision;
 
-	let result = Math[method](Number(number * power).toPrecision(15)) / power;
+	let result = Math[method](Number((number * power).toPrecision(15))) / power;
 
 	if (isRoundingAndNegative) {
 		result = -result;

--- a/test.js
+++ b/test.js
@@ -12,7 +12,7 @@ test('roundTo()', t => {
 	t.false(Number.isNaN(roundTo(10000000000000, 8)));
 	t.is(roundTo(0.37542323423423432432432432432, 8), 0.37542323);
 	t.is(roundTo(0.1231782638, Infinity), 0.1231782638);
-	t.is(roundTo(0.597/6, 3), 0.1);
+	t.is(roundTo(0.597 / 6, 3), 0.1);
 });
 
 test('roundTo.up()', t => {
@@ -23,7 +23,7 @@ test('roundTo.up()', t => {
 	t.is(roundTo.up(1.111, 0), 2);
 	t.is(roundTo.up(111.1, -2), 200);
 	t.is(roundTo.up(-0.375, 2), -0.37);
-	t.is(roundTo.up((0.1+0.2)*10, 0), 3);
+	t.is(roundTo.up((0.1 + 0.2) * 10, 0), 3);
 });
 
 test('roundTo.down()', t => {
@@ -34,5 +34,5 @@ test('roundTo.down()', t => {
 	t.is(roundTo.down(1.006, 0), 1);
 	t.is(roundTo.down(111.6, -2), 100);
 	t.is(roundTo.down(-0.375, 2), -0.38);
-	t.is(roundTo.down((0.1+0.7)*10, 0), 8);
+	t.is(roundTo.down((0.1 + 0.7) * 10, 0), 8);
 });

--- a/test.js
+++ b/test.js
@@ -12,6 +12,7 @@ test('roundTo()', t => {
 	t.false(Number.isNaN(roundTo(10000000000000, 8)));
 	t.is(roundTo(0.37542323423423432432432432432, 8), 0.37542323);
 	t.is(roundTo(0.1231782638, Infinity), 0.1231782638);
+	t.is(roundTo(0.597/6, 3), 0.1);
 });
 
 test('roundTo.up()', t => {
@@ -22,6 +23,7 @@ test('roundTo.up()', t => {
 	t.is(roundTo.up(1.111, 0), 2);
 	t.is(roundTo.up(111.1, -2), 200);
 	t.is(roundTo.up(-0.375, 2), -0.37);
+	t.is(roundTo.up((0.1+0.2)*10, 0), 3);
 });
 
 test('roundTo.down()', t => {
@@ -32,4 +34,5 @@ test('roundTo.down()', t => {
 	t.is(roundTo.down(1.006, 0), 1);
 	t.is(roundTo.down(111.6, -2), 100);
 	t.is(roundTo.down(-0.375, 2), -0.38);
+	t.is(roundTo.down((0.1+0.7)*10, 0), 8);
 });


### PR DESCRIPTION
I suggest to use the **toPrecision()** method to preround the result to 15 significant digits. This will strip the floating-point round-off errors in the intermediate calculations.

Please refer to my answer on stackoverflow https://stackoverflow.com/a/48764436

Fixes #20 