### PR TITLE
Don't convert the string back to a number since rounding functions support strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function round(method, number, precision) {
 
 	const power = 10 ** precision;
 
-	let result = Math[method](Number((number * power).toPrecision(15))) / power;
+	let result = Math[method]((number * power).toPrecision(15)) / power;
 
 	if (isRoundingAndNegative) {
 		result = -result;


### PR DESCRIPTION
```js
console.log(Math.round('1.5'))
//=> 2
```