### PR TITLE
Add tests for -0 and high precision values

### DIFF
--- a/test.js
+++ b/test.js
@@ -25,6 +25,8 @@ test('roundTo()', t => {
 	t.is(roundTo(0.597 / 6, 3), 0.1);
 	t.is(roundTo(6.578040334659363e-10, 6), 0);
 	t.is(roundTo(-6.578040334659363e-10, 6), -0);
+	t.is(roundTo(0, 1), 0);
+	t.is(roundTo(-0, 1), 0);
 });
 
 test('roundToUp()', t => {
@@ -45,6 +47,8 @@ test('roundToUp()', t => {
 	t.is(roundToUp((0.1 + 0.2) * 10, 0), 3);
 	t.is(roundToUp(6.578040334659363e-10, 6), 0.000001);
 	t.is(roundToUp(-6.578040334659363e-10, 6), -0);
+	t.is(roundToUp(0, 1), 0);
+	t.is(roundToUp(-0, 1), 0);
 });
 
 test('roundToDown()', t => {
@@ -65,4 +69,6 @@ test('roundToDown()', t => {
 	t.is(roundToDown((0.1 + 0.7) * 10, 0), 8);
 	t.is(roundToDown(6.578040334659363e-10, 6), 0);
 	t.is(roundToDown(-6.578040334659363e-10, 6), -0.000001);
+	t.is(roundToDown(0, 1), 0);
+	t.is(roundToDown(-0, 1), 0);
 });

--- a/test.js
+++ b/test.js
@@ -23,6 +23,8 @@ test('roundTo()', t => {
 	t.is(roundTo(1262.48, -1), 1260);
 	t.is(roundTo(1262.48, -2), 1300);
 	t.is(roundTo(0.597 / 6, 3), 0.1);
+	t.is(roundTo(6.578040334659363e-10, 6), 0);
+	t.is(roundTo(-6.578040334659363e-10, 6), -0);
 });
 
 test('roundToUp()', t => {
@@ -41,6 +43,8 @@ test('roundToUp()', t => {
 	t.is(roundToUp(-2.26, 2), -2.26);
 	t.is(roundToUp(-18.15, 2), -18.15);
 	t.is(roundToUp((0.1 + 0.2) * 10, 0), 3);
+	t.is(roundToUp(6.578040334659363e-10, 6), 0.000001);
+	t.is(roundToUp(-6.578040334659363e-10, 6), -0);
 });
 
 test('roundToDown()', t => {
@@ -59,4 +63,6 @@ test('roundToDown()', t => {
 	t.is(roundToDown(2.26, 2), 2.26);
 	t.is(roundToDown(18.15, 2), 18.15);
 	t.is(roundToDown((0.1 + 0.7) * 10, 0), 8);
+	t.is(roundToDown(6.578040334659363e-10, 6), 0);
+	t.is(roundToDown(-6.578040334659363e-10, 6), -0.000001);
 });


### PR DESCRIPTION
Is it on purpose to round `-6.578040334659363e-10` to `-0` instead of `0`? 🤔 
Shouldn't be better to never round to `-0` but `0` instead 🤔 

Related to https://github.com/sindresorhus/round-to/issues/28